### PR TITLE
Feat/itn distribution timing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: site
 Type: Package
 Title: Site specific malariasimulation modelling
-Version: 0.2.2
+Version: 0.2.3
 Authors@R: c(
     person("Pete", "Winskill", email = "p.winskill@imperial.ac.uk", role = c("aut", "cre"))
     )

--- a/R/interventions.R
+++ b/R/interventions.R
@@ -108,8 +108,11 @@ add_treatment <- function(p, interventions){
 #'
 #' @return modified parameter list
 add_itns <- function(p, interventions){
-  # Assuming net distribution happens on January 1st
-  timesteps <- 1 + (interventions$year - p$baseline_year) * 365
+
+  if(!"itn_distribution_day" %in% colnames(interventions)){
+    interventions$itn_distribution_day <- 1
+  }
+  timesteps <- interventions$itn_distribution_day + (interventions$year - p$baseline_year) * 365
   # Net retention half life does not vary over time (Should match what is used when fitting input dist)
   retention <- 365 * 5
   # Net input coverage

--- a/R/interventions.R
+++ b/R/interventions.R
@@ -109,6 +109,7 @@ add_treatment <- function(p, interventions){
 #' @return modified parameter list
 add_itns <- function(p, interventions){
 
+  # If not specified, assume distribution happens January 1st
   if(!"itn_distribution_day" %in% colnames(interventions)){
     interventions$itn_distribution_day <- 1
   }


### PR DESCRIPTION
Add in an option to specifiy the day of the year for itn distributions.
If not included as as column in the interventions inputs it will revert to the previous default of Jan 1st