### PR TITLE
Added malariasimulation::set_parameter_draw() to site_parameters

### DIFF
--- a/R/site_parameters.R
+++ b/R/site_parameters.R
@@ -8,6 +8,7 @@
 #' @param species Can be falciparum: "pf" or vivax: "pv", for vivax SMC, RTSS
 #'  and PMC are not implemented
 #' @param eir Site baseline EIR
+#' @param draw malariasimulation parameter draw
 #' @param overrides List of malariasimulation default parameter overrides
 #' @param burnin Number of burn in years
 #'
@@ -15,7 +16,7 @@
 #' @export
 site_parameters <- function(interventions, demography, vectors, seasonality,
                             min_ages = c(0, 5, 15) * 365, species = "pf",
-                            eir = NULL, overrides = list(), burnin = 0){
+                            eir = NULL, draw = NULL, overrides = list(), burnin = 0){
 
   p <- malariasimulation::get_parameters(overrides = overrides)
 
@@ -35,9 +36,16 @@ site_parameters <- function(interventions, demography, vectors, seasonality,
                       species = species) |>
     set_age_outputs(min_ages = min_ages)
 
+  if(species == "pf") {
+    if(!is.null(draw)){
+      p <- malariasimulation::set_parameter_draw(p, draw)
+    }
+  }
+
   if(!is.null(eir)){
     p <- malariasimulation::set_equilibrium(p, init_EIR = eir)
   }
 
   return(p)
 }
+

--- a/R/site_parameters.R
+++ b/R/site_parameters.R
@@ -8,7 +8,7 @@
 #' @param species Can be falciparum: "pf" or vivax: "pv", for vivax SMC, RTSS
 #'  and PMC are not implemented
 #' @param eir Site baseline EIR
-#' @param draw malariasimulation parameter draw
+#' @param draw malariasimulation parameter draw. Default NULL is best-fit parameter set
 #' @param overrides List of malariasimulation default parameter overrides
 #' @param burnin Number of burn in years
 #'

--- a/R/site_parameters.R
+++ b/R/site_parameters.R
@@ -14,14 +14,26 @@
 #'
 #' @return A malariasimulation parameter list
 #' @export
-site_parameters <- function(interventions, demography, vectors, seasonality,
-                            min_ages = c(0, 5, 15) * 365, species = "pf",
-                            eir = NULL, draw = NULL, overrides = list(), burnin = 0){
-
+site_parameters <- function(
+  interventions,
+  demography,
+  vectors,
+  seasonality,
+  min_ages = c(0, 5, 15) * 365,
+  species = "pf",
+  eir = NULL,
+  draw = NULL,
+  overrides = list(),
+  burnin = 0
+) {
   p <- malariasimulation::get_parameters(overrides = overrides)
 
+  if (!is.null(draw)) {
+    p <- malariasimulation::set_parameter_draw(p, draw)
+  }
+
   p$burnin <- 0
-  if(burnin > 0){
+  if (burnin > 0) {
     p$burnin <- burnin
     interventions <- burnin_interventions(interventions, burnin)
     demography <- burnin_demography(demography, burnin)
@@ -32,20 +44,12 @@ site_parameters <- function(interventions, demography, vectors, seasonality,
     add_seasonality(seasonality = seasonality) |>
     add_vectors(vectors = vectors) |>
     add_demography(demography = demography) |>
-    add_interventions(interventions = interventions,
-                      species = species) |>
+    add_interventions(interventions = interventions, species = species) |>
     set_age_outputs(min_ages = min_ages)
 
-  if(species == "pf") {
-    if(!is.null(draw)){
-      p <- malariasimulation::set_parameter_draw(p, draw)
-    }
-  }
-
-  if(!is.null(eir)){
+  if (!is.null(eir)) {
     p <- malariasimulation::set_equilibrium(p, init_EIR = eir)
   }
 
   return(p)
 }
-

--- a/man/site_parameters.Rd
+++ b/man/site_parameters.Rd
@@ -12,6 +12,7 @@ site_parameters(
   min_ages = c(0, 5, 15) * 365,
   species = "pf",
   eir = NULL,
+  draw = NULL,
   overrides = list(),
   burnin = 0
 )
@@ -31,6 +32,8 @@ site_parameters(
 and PMC are not implemented}
 
 \item{eir}{Site baseline EIR}
+
+\item{draw}{malariasimulation parameter draw}
 
 \item{overrides}{List of malariasimulation default parameter overrides}
 

--- a/tests/testthat/test-site_parameters.R
+++ b/tests/testthat/test-site_parameters.R
@@ -18,7 +18,6 @@ test_that("site parameters wrapper works", {
   expect_type(p, "list")
 })
 
-
 test_that("setting vivax works", {
   single_site <- subset_site(example_site, example_site$eir[1,])
   single_site$interventions$rtss_cov <- 0.1
@@ -35,4 +34,61 @@ test_that("setting vivax works", {
   expect_false(p$pev)
   expect_false(p$smc)
   expect_false(p$pmc)
+})
+
+test_that("setting parameter draw works for falciparum", {
+
+  single_site <- subset_site(example_site, example_site$eir[1,])
+
+  p <- site_parameters(
+    interventions = single_site$interventions,
+    demography = single_site$demography,
+    vectors = single_site$vectors$vector_species,
+    seasonality = single_site$seasonality$seasonality_parameters,
+    species = "pf",
+    eir = 10,
+    draw = 1000
+  )
+
+  parameter_names_pf <- names(malariasimulation::parameter_draws_pf[[1000]])
+
+  expect_identical(p[parameter_names_pf], parameter_draws_pf[[1000]][parameter_names_pf])
+
+})
+
+test_that("parameter draw functionality switched off for vivax", {
+
+  single_site <- subset_site(example_site, example_site$eir[1,])
+
+  p <- site_parameters(
+    interventions = single_site$interventions,
+    demography = single_site$demography,
+    vectors = single_site$vectors$vector_species,
+    seasonality = single_site$seasonality$seasonality_parameters,
+    species = "pv",
+    eir = 10,
+    draw = 10
+  )
+
+  parameter_names_pf <- names(parameter_draws_pf)
+
+  expect_identical(get_parameters()[parameter_names_pf], p[parameter_names_pf])
+
+})
+
+test_that("set_equilibrium not called when eir argument left at default", {
+
+  single_site <- subset_site(example_site, example_site$eir[1,])
+
+  p <- site_parameters(
+    interventions = single_site$interventions,
+    demography = single_site$demography,
+    vectors = single_site$vectors$vector_species,
+    seasonality = single_site$seasonality$seasonality_parameters,
+    species = "pf")
+
+  expect_null(p$eq_params)
+  expect_null(p$init_EIR)
+  expect_identical(p$init_foim, 0)
+
 })

--- a/tests/testthat/test-site_parameters.R
+++ b/tests/testthat/test-site_parameters.R
@@ -52,27 +52,7 @@ test_that("setting parameter draw works for falciparum", {
 
   parameter_names_pf <- names(malariasimulation::parameter_draws_pf[[1000]])
 
-  expect_identical(p[parameter_names_pf], parameter_draws_pf[[1000]][parameter_names_pf])
-
-})
-
-test_that("parameter draw functionality switched off for vivax", {
-
-  single_site <- subset_site(example_site, example_site$eir[1,])
-
-  p <- site_parameters(
-    interventions = single_site$interventions,
-    demography = single_site$demography,
-    vectors = single_site$vectors$vector_species,
-    seasonality = single_site$seasonality$seasonality_parameters,
-    species = "pv",
-    eir = 10,
-    draw = 10
-  )
-
-  parameter_names_pf <- names(parameter_draws_pf)
-
-  expect_identical(get_parameters()[parameter_names_pf], p[parameter_names_pf])
+  expect_identical(p[parameter_names_pf], malariasimulation::parameter_draws_pf[[1000]][parameter_names_pf])
 
 })
 


### PR DESCRIPTION
I've added `draw` as an argument to to `site_parameters()` with a default value of `NULL`. If `draw != NULL`, then site_parameters runs the parameter list (`p`) through `malaria::simulation::set_parameter_draw(draw = draw)`. This functionality is only available for _Plasmodium flaciparum_ (if `species == "pf"`) as the functionality to use `site_parameters()` to generate parameter lists for _Plasmodium vivax_ isn't currently available. I've also added some simple unit tests. 
