### PR TITLE
Assign orderly parameters call to variable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: site
 Type: Package
 Title: Site specific malariasimulation modelling
-Version: 1.0.7
+Version: 1.0.8
 Authors@R: c(
     person("Pete", "Winskill", email = "p.winskill@imperial.ac.uk", role = c("aut", "cre"))
     )

--- a/R/test-helpers.R
+++ b/R/test-helpers.R
@@ -44,7 +44,7 @@ create_orderly_packet <- function(name, files, parameters = list(), root) {
   withr::defer(fs::dir_delete(src))
 
   args <- paste0(sprintf("%s = NULL", names(parameters)), collapse=",")
-  code <- sprintf("orderly2::orderly_parameters(%s)", args)
+  code <- sprintf("p <- orderly2::orderly_parameters(%s)", args)
   writeLines(code, fs::path(src, sprintf("%s.R", name)))
 
   for (i in seq_along(files)) {


### PR DESCRIPTION
Update to support orderly2 parameter handling

This PR updates usage of orderly_parameters() to comply with recent changes in orderly2. Specifically, it assigns the result of orderly_parameters() to a variable, avoiding the now-deprecated behaviour of implicitly copying parameters into the environment.

This resolves the following warning:
```
You must assign calls to 'orderly_parameters()' to a variable
i The old behaviour of automatically copying parameters into the environment has been deprecated, and you should move to the new behaviour as soon as possible
i See `?orderly_parameters()` for details
```

No changes to model logic or outputs.