### PR TITLE
Switch to the CRAN version of orderly.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,15 +11,14 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Remotes:
-    mrc-ide/malariasimulation,
-    mrc-ide/orderly2
+    mrc-ide/malariasimulation
 Config/testthat/edition: 3
 RoxygenNote: 7.3.2
 Depends: 
     R (>= 2.10),
     sf
 Imports: 
-    orderly2,
+    orderly,
     dplyr,
     malariasimulation,
     rappdirs,

--- a/R/fetch.R
+++ b/R/fetch.R
@@ -21,18 +21,18 @@ location_configuration <- function() {
 #' the new parameters. If it exists and has the same parameters already nothing
 #' happens.
 #'
-#' This functionality could probably be moved to the orderly2 package.
+#' This functionality could probably be moved to the orderly package.
 #' @noRd
 location_add_or_update <- function(name, type, args, root) {
-  locations <- orderly2::orderly_location_list(root = root, verbose = TRUE)
+  locations <- orderly::orderly_location_list(root = root, verbose = TRUE)
   locations <- locations[locations$name == name,]
 
   if (nrow(locations) == 0) {
-    orderly2::orderly_location_add(name, type, args, root = root)
+    orderly::orderly_location_add(name, type, args, root = root)
   } else if (locations[[1, "type"]] != type ||
              !identical(locations[[1, "args"]], args)) {
-    orderly2::orderly_location_remove(name, root = root)
-    orderly2::orderly_location_add(name, type, args, root = root)
+    orderly::orderly_location_remove(name, root = root)
+    orderly::orderly_location_add(name, type, args, root = root)
   }
 }
 
@@ -56,7 +56,7 @@ location_add_or_update <- function(name, type, args, root) {
 configure_orderly <- function() {
   root <- file.path(rappdirs::user_cache_dir("malariaverse-sitefiles"), "store")
 
-  orderly2::orderly_init(root, use_file_store = TRUE)
+  orderly::orderly_init(root, use_file_store = TRUE)
 
   cfg <- location_configuration()
   location_add_or_update(LOCATION_NAME, type = cfg$type, args = cfg$args,
@@ -90,7 +90,7 @@ fetch_files <- function(name, parameters, dest, files, expr = NULL) {
     expr <- sprintf("latest(%s)", filter)
   }
 
-  plan <- orderly2::orderly_copy_files(
+  plan <- orderly::orderly_copy_files(
     name = name,
     expr = expr,
     parameters = parameters,
@@ -172,7 +172,7 @@ fetch_site <- function(iso3c = NULL, version = NULL,
 #' @return Version table.
 #' @export
 available_sites <- function(){
-  pulled <- orderly2::orderly_metadata_extract(
+  pulled <- orderly::orderly_metadata_extract(
     name = "calibration",
     extract = c(
       version = "parameters.version",

--- a/R/test-helpers.R
+++ b/R/test-helpers.R
@@ -1,6 +1,6 @@
 local_orderly_root <- function(..., .local_envir = parent.frame()) {
   root <- withr::local_tempdir(.local_envir = .local_envir)
-  suppressMessages(orderly2::orderly_init(root, ...))
+  suppressMessages(orderly::orderly_init(root, ...))
   root
 }
 
@@ -44,7 +44,7 @@ create_orderly_packet <- function(name, files, parameters = list(), root) {
   withr::defer(fs::dir_delete(src))
 
   args <- paste0(sprintf("%s = NULL", names(parameters)), collapse=",")
-  code <- sprintf("p <- orderly2::orderly_parameters(%s)", args)
+  code <- sprintf("p <- orderly::orderly_parameters(%s)", args)
   writeLines(code, fs::path(src, sprintf("%s.R", name)))
 
   for (i in seq_along(files)) {
@@ -55,6 +55,6 @@ create_orderly_packet <- function(name, files, parameters = list(), root) {
       writeLines(files[[i]], f)
     }
   }
-  suppressMessages(orderly2::orderly_run(name, parameters, echo = FALSE,
-                                         root = root))
+  suppressMessages(orderly::orderly_run(name, parameters, echo = FALSE,
+                                        root = root))
 }

--- a/tests/testthat/test-fetch.R
+++ b/tests/testthat/test-fetch.R
@@ -24,7 +24,7 @@ test_that("can configure orderly repository", {
 
   root <- suppressMessages(configure_orderly())
   expect_true(fs::dir_exists(root))
-  expect_contains(orderly2::orderly_location_list(root = root), LOCATION_NAME)
+  expect_contains(orderly::orderly_location_list(root = root), LOCATION_NAME)
 })
 
 test_that("can change orderly location", {
@@ -37,7 +37,7 @@ test_that("can change orderly location", {
     args = list(path = upstream1)))
 
   root <- suppressMessages(configure_orderly())
-  res <- orderly2::orderly_location_list(root = root, verbose = TRUE)
+  res <- orderly::orderly_location_list(root = root, verbose = TRUE)
   expect_equal(res[[which(res$name == LOCATION_NAME), "args"]]$path, upstream1)
 
   withr::local_options("site.orderly_location" = list(
@@ -45,7 +45,7 @@ test_that("can change orderly location", {
     args = list(path = upstream2)))
 
   root <- configure_orderly()
-  res <- orderly2::orderly_location_list(root = root, verbose = TRUE)
+  res <- orderly::orderly_location_list(root = root, verbose = TRUE)
 
   expect_equal(res[[which(res$name == LOCATION_NAME), "args"]]$path, upstream2)
 })


### PR DESCRIPTION
orderly2 has recently been renamed to orderly and is now available directly from CRAN.

Fixes #51