### PR TITLE
fastforward paper branch based on updates in main (for VIMC malaria paper)

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -41,7 +41,15 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages:
+            # Having malariaEquilibrium listed here makes no sense as it is
+            # already part of malariasimulation's dependencies. However there
+            # is some kind of bug in pkgdepends that triggers if we don't add
+            # it. The bug only happens on Windows.
+            # See comments in https://github.com/mrc-ide/site/pull/44
+            mrc-ide/malariaEquilibrium,
+            any::rcmdcheck
+
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: site
 Type: Package
 Title: Site specific malariasimulation modelling
-Version: 1.0.8
+Version: 1.0.9
 Authors@R: c(
     person("Pete", "Winskill", email = "p.winskill@imperial.ac.uk", role = c("aut", "cre"))
     )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: site
 Type: Package
 Title: Site specific malariasimulation modelling
-Version: 1.0.7
+Version: 1.0.8
 Authors@R: c(
     person("Pete", "Winskill", email = "p.winskill@imperial.ac.uk", role = c("aut", "cre"))
     )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,15 +11,14 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Remotes:
-    mrc-ide/malariasimulation,
-    mrc-ide/orderly2
+    mrc-ide/malariasimulation
 Config/testthat/edition: 3
 RoxygenNote: 7.3.2
 Depends: 
     R (>= 2.10),
     sf
 Imports: 
-    orderly2,
+    orderly,
     dplyr,
     malariasimulation,
     rappdirs,

--- a/R/fetch.R
+++ b/R/fetch.R
@@ -9,7 +9,7 @@ location_configuration <- function() {
   getOption("site.orderly_location", list(
     type = "packit",
     args = list(
-      url = "https://packit.dide.ic.ac.uk/malariaverse-sitefiles",
+      url = "https://malariaverse-sitefiles.packit.dide.ic.ac.uk",
       token = token)
   ))
 }

--- a/R/fetch.R
+++ b/R/fetch.R
@@ -110,6 +110,11 @@ fetch_files <- function(name, parameters, dest, files, expr = NULL) {
 #' The site file is identified by its country code, and optionally the
 #' admin_level, urban/rural setting and version of the site files. The latest
 #' packet from the server matching these parameters is used.
+#' By default, calling `fetch_site()` with only `iso3c` downloads the latest
+#' available version. For reproducibility and stable workflows, it is strongly
+#' recommended to specify `version`, `admin_level`, and `urban_rural` explicitly,
+#' or to download and store site files locally. Otherwise, downstream pipelines
+#' may break when new site file versions are released.
 #'
 #' Alternatively, a packet ID can be specified in order to pick an exact file
 #' set.

--- a/R/fetch.R
+++ b/R/fetch.R
@@ -21,18 +21,18 @@ location_configuration <- function() {
 #' the new parameters. If it exists and has the same parameters already nothing
 #' happens.
 #'
-#' This functionality could probably be moved to the orderly2 package.
+#' This functionality could probably be moved to the orderly package.
 #' @noRd
 location_add_or_update <- function(name, type, args, root) {
-  locations <- orderly2::orderly_location_list(root = root, verbose = TRUE)
+  locations <- orderly::orderly_location_list(root = root, verbose = TRUE)
   locations <- locations[locations$name == name,]
 
   if (nrow(locations) == 0) {
-    orderly2::orderly_location_add(name, type, args, root = root)
+    orderly::orderly_location_add(name, type, args, root = root)
   } else if (locations[[1, "type"]] != type ||
              !identical(locations[[1, "args"]], args)) {
-    orderly2::orderly_location_remove(name, root = root)
-    orderly2::orderly_location_add(name, type, args, root = root)
+    orderly::orderly_location_remove(name, root = root)
+    orderly::orderly_location_add(name, type, args, root = root)
   }
 }
 
@@ -56,7 +56,7 @@ location_add_or_update <- function(name, type, args, root) {
 configure_orderly <- function() {
   root <- file.path(rappdirs::user_cache_dir("malariaverse-sitefiles"), "store")
 
-  orderly2::orderly_init(root, use_file_store = TRUE)
+  orderly::orderly_init(root, use_file_store = TRUE)
 
   cfg <- location_configuration()
   location_add_or_update(LOCATION_NAME, type = cfg$type, args = cfg$args,
@@ -90,7 +90,7 @@ fetch_files <- function(name, parameters, dest, files, expr = NULL) {
     expr <- sprintf("latest(%s)", filter)
   }
 
-  plan <- orderly2::orderly_copy_files(
+  plan <- orderly::orderly_copy_files(
     name = name,
     expr = expr,
     parameters = parameters,
@@ -172,7 +172,7 @@ fetch_site <- function(iso3c = NULL, version = NULL,
 #' @return Version table.
 #' @export
 available_sites <- function(){
-  pulled <- orderly2::orderly_metadata_extract(
+  pulled <- orderly::orderly_metadata_extract(
     name = "calibration",
     extract = c(
       version = "parameters.version",

--- a/R/test-helpers.R
+++ b/R/test-helpers.R
@@ -44,7 +44,7 @@ create_orderly_packet <- function(name, files, parameters = list(), root) {
   withr::defer(fs::dir_delete(src))
 
   args <- paste0(sprintf("%s = NULL", names(parameters)), collapse=",")
-  code <- sprintf("orderly2::orderly_parameters(%s)", args)
+  code <- sprintf("p <- orderly2::orderly_parameters(%s)", args)
   writeLines(code, fs::path(src, sprintf("%s.R", name)))
 
   for (i in seq_along(files)) {

--- a/R/test-helpers.R
+++ b/R/test-helpers.R
@@ -1,6 +1,6 @@
 local_orderly_root <- function(..., .local_envir = parent.frame()) {
   root <- withr::local_tempdir(.local_envir = .local_envir)
-  suppressMessages(orderly2::orderly_init(root, ...))
+  suppressMessages(orderly::orderly_init(root, ...))
   root
 }
 
@@ -44,7 +44,7 @@ create_orderly_packet <- function(name, files, parameters = list(), root) {
   withr::defer(fs::dir_delete(src))
 
   args <- paste0(sprintf("%s = NULL", names(parameters)), collapse=",")
-  code <- sprintf("p <- orderly2::orderly_parameters(%s)", args)
+  code <- sprintf("p <- orderly::orderly_parameters(%s)", args)
   writeLines(code, fs::path(src, sprintf("%s.R", name)))
 
   for (i in seq_along(files)) {
@@ -55,6 +55,6 @@ create_orderly_packet <- function(name, files, parameters = list(), root) {
       writeLines(files[[i]], f)
     }
   }
-  suppressMessages(orderly2::orderly_run(name, parameters, echo = FALSE,
-                                         root = root))
+  suppressMessages(orderly::orderly_run(name, parameters, echo = FALSE,
+                                        root = root))
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -26,6 +26,12 @@ The site package supports malariaverse users to:
 1. Access and download the latest country site-files 🌐 ➡️ 💻
 2. Translate site file information into malariasimulation parameters 🌍 ➡️ 📉
 
+:warning: The site package streamlines model runs for specific geographies, 
+but it also encapsulates many underlying assumptions, limitations, and 
+uncertainties. Mis-specifying inputs or misinterpreting outputs from the complex
+malariasimulation model remains very possible. We strongly recommend consulting a 
+member of the Imperial College modelling team before using these results for 
+science, policy or decision-making purposes.
 
 
 ## The site-file

--- a/README.Rmd
+++ b/README.Rmd
@@ -33,6 +33,8 @@ malariasimulation model remains very possible. We strongly recommend consulting 
 member of the Imperial College modelling team before using these results for 
 science, policy or decision-making purposes.
 
+Email: malariaverse@imperial.ac.uk
+
 
 ## The site-file
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -33,6 +33,14 @@ malariasimulation model remains very possible. We strongly recommend consulting 
 member of the Imperial College modelling team before using these results for 
 science, policy or decision-making purposes.
 
+<div style="font-weight: bold;">
+While every effort has been made to ensure the reliability of the package and 
+its outputs, the authors, contributors, and affiliated institutions accept no 
+responsibility or liability for any errors, omissions, or consequences arising 
+from their use. All results should be interpreted with caution and professional 
+judgement.
+</div>
+
 Email: malariaverse@imperial.ac.uk
 
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ The site package supports malariaverse users to:
 2.  Translate site file information into malariasimulation parameters 🌍
     ➡️ 📉
 
+:warning: The site package streamlines model runs for specific
+geographies, but it also encapsulates many underlying assumptions,
+limitations, and uncertainties. Mis-specifying inputs or misinterpreting
+outputs from the complex malariasimulation model remains very possible.
+We strongly recommend consulting a member of the Imperial College
+modelling team before using these results for science, policy or
+decision-making purposes.
+
 ## The site-file
 
 The site-file is the file storing all of the sub nationally

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ We strongly recommend consulting a member of the Imperial College
 modelling team before using these results for science, policy or
 decision-making purposes.
 
+<div style="font-weight: bold;">
+
+While every effort has been made to ensure the reliability of the
+package and its outputs, the authors, contributors, and affiliated
+institutions accept no responsibility or liability for any errors,
+omissions, or consequences arising from their use. All results should be
+interpreted with caution and professional judgement.
+
+</div>
+
 Email: <malariaverse@imperial.ac.uk>
 
 ## The site-file

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ We strongly recommend consulting a member of the Imperial College
 modelling team before using these results for science, policy or
 decision-making purposes.
 
+Email: <malariaverse@imperial.ac.uk>
+
 ## The site-file
 
 The site-file is the file storing all of the sub nationally

--- a/man/fetch_site.Rd
+++ b/man/fetch_site.Rd
@@ -30,6 +30,11 @@ The contents of the site file.
 The site file is identified by its country code, and optionally the
 admin_level, urban/rural setting and version of the site files. The latest
 packet from the server matching these parameters is used.
+By default, calling `fetch_site()` with only `iso3c` downloads the latest
+available version. For reproducibility and stable workflows, it is strongly
+recommended to specify `version`, `admin_level`, and `urban_rural` explicitly,
+or to download and store site files locally. Otherwise, downstream pipelines
+may break when new site file versions are released.
 }
 \details{
 Alternatively, a packet ID can be specified in order to pick an exact file

--- a/tests/testthat/test-fetch.R
+++ b/tests/testthat/test-fetch.R
@@ -24,7 +24,7 @@ test_that("can configure orderly repository", {
 
   root <- suppressMessages(configure_orderly())
   expect_true(fs::dir_exists(root))
-  expect_contains(orderly2::orderly_location_list(root = root), LOCATION_NAME)
+  expect_contains(orderly::orderly_location_list(root = root), LOCATION_NAME)
 })
 
 test_that("can change orderly location", {
@@ -37,7 +37,7 @@ test_that("can change orderly location", {
     args = list(path = upstream1)))
 
   root <- suppressMessages(configure_orderly())
-  res <- orderly2::orderly_location_list(root = root, verbose = TRUE)
+  res <- orderly::orderly_location_list(root = root, verbose = TRUE)
   expect_equal(res[[which(res$name == LOCATION_NAME), "args"]]$path, upstream1)
 
   withr::local_options("site.orderly_location" = list(
@@ -45,7 +45,7 @@ test_that("can change orderly location", {
     args = list(path = upstream2)))
 
   root <- configure_orderly()
-  res <- orderly2::orderly_location_list(root = root, verbose = TRUE)
+  res <- orderly::orderly_location_list(root = root, verbose = TRUE)
 
   expect_equal(res[[which(res$name == LOCATION_NAME), "args"]]$path, upstream2)
 })

--- a/vignettes/Accessing-site-files.Rmd
+++ b/vignettes/Accessing-site-files.Rmd
@@ -38,7 +38,8 @@ When you receive confirmation of this (look out for a notification on github), y
 can then use the `site` package inbuilt functionality to download site files.
 
 You can call `fetch_site()`, specifying the [ISO3c country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) of your
-country of interest. For example, for Nigeria: `fetch_site(iso3c = "NGA")`.
+country of interest. For example, for Nigeria: 
+`fetch_site(iso3c = "NGA", admin_level = 1, urban_rural = TRUE)`.
 
 The first time you do this, you will see interactive authentication instructions
 asking you to access a github link and providing an authentication code. Open
@@ -46,10 +47,17 @@ the link and copy the code to authorise access. This process should cache your
 credentials so that you don't have to authorise every time.
 
 ## Updates and versioning
+Site files are periodically updated.
+You can check which version you have by inspecting the site metadata. 
+The function `available_sites()` lists all site files currently available on the server.
 
-Site files will be periodically updated. You can see the version of sitefile
-you have by looking at the site metadata. Calling `available_sites()` provides
-more information about what site files are available on the server.
+By default, `fetch_site(iso3c = ...)` downloads the latest version of a site file.
+For reproducibility, you can also specify admin_level, urban_rural, and version 
+to fetch a particular file.
+
+For stable workflows, we recommend downloading and storing the site files you 
+use once, rather than always pulling the latest version. Otherwise, downstream 
+pipelines may break if new site file options become available.
 
 News on new updates will be posted [here](https://mrc-ide.github.io/site/news/index.html).
 

--- a/vignettes/Interventions.Rmd
+++ b/vignettes/Interventions.Rmd
@@ -114,7 +114,7 @@ Given an ITN type and level of pyrethroid insecticide resistance, we can link to
 corresponding estimates of the key ITN efficacy parameters. These have been 
 estimated by Ellie Sherrard-Smith *et al* @sherrard2022. 
 Please note that gamman is provided in units of years here, these will need to be converted to days for use in 
-malariasimulaiton. 
+malariasimulation (`site_parameters()` does this for you). 
 
 ## IRS
 


### PR DESCRIPTION
should resolve issue with orderly2 dependency (now that orderly2 was renamed to orderly)